### PR TITLE
Fix Transactions

### DIFF
--- a/TobyMeehan.Com/Components/Pagination.razor
+++ b/TobyMeehan.Com/Components/Pagination.razor
@@ -48,21 +48,15 @@
 
             if (lower < 0)
             {
-                higher += lower * -1;
+                higher = (Range * 2);
                 lower = 0;
             }
 
             if (higher >= Items.Count())
             {
-                lower -= higher - Items.Count();
+                lower = Items.Count() - 1 - (Range * 2);
                 higher = Items.Count() - 1;
             }
-
-            if (lower < 0)
-            {
-                lower = 0;
-            }
-
 
             for (int i = lower; i <= higher; i++)
             {

--- a/TobyMeehan.Com/Pages/Settings/Transactions.razor
+++ b/TobyMeehan.Com/Pages/Settings/Transactions.razor
@@ -8,11 +8,15 @@
 </Card>
 
 <Card class="my-3">
-    <p>Balance: @CurrentUser.Balance</p>
+    <p class="lead"><strong>Balance:</strong> @CurrentUser.Balance</p>
 
     @if (_transactions == null)
     {
         <Loading></Loading>
+    }
+    else if (_transactions.Count <= 0)
+    {
+        <p>You have no transactions.</p>
     }
     else
     {

--- a/TobyMeehan.Com/Pages/Settings/Transactions.razor
+++ b/TobyMeehan.Com/Pages/Settings/Transactions.razor
@@ -20,7 +20,7 @@
     }
     else
     {
-        <Pagination Items="_transactions" Range="5" class="justify-content-center">
+        <Pagination Items="_transactions" Range="2" class="justify-content-center">
             <Table>
                 <Head>
                     <tr>

--- a/TobyMeehan.Com/Pages/Settings/Transactions.razor.cs
+++ b/TobyMeehan.Com/Pages/Settings/Transactions.razor.cs
@@ -24,7 +24,7 @@ namespace TobyMeehan.Com.Pages.Settings
         {
             var ts = await Task.Run(async () => await transactions.GetByUserAsync(CurrentUser.Id));
 
-            _transactions = ts.OrderBy(x => x.Sent).GroupBy(x => x.Sent.Date).Reverse().ToList();
+            _transactions = ts.OrderByDescending(x => x.Sent).GroupBy(x => x.Sent.Date).ToList();
         }
     }
 }


### PR DESCRIPTION
- Fixed crash when loading transactions page with no transactions.
- Updated pagination to work properly and limit range to 5 items.
- Transactions now appear in descending time order.